### PR TITLE
Fix error of find_library under linux platform

### DIFF
--- a/pyclibrary/utils.py
+++ b/pyclibrary/utils.py
@@ -92,7 +92,7 @@ def find_header(h_name, dirs=None):
                      '/System/Library/Frameworks', '/Library/Frameworks'))
 
     if sys.platform == 'linux2':
-        dirs.append(('/usr/local/include', '/usr/target/include',
+        dirs.extend(('/usr/local/include', '/usr/target/include',
                      '/usr/include'))
 
     for d in dirs:


### PR DESCRIPTION
The following error will happend while under linux platform:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/IPython/core/interactiveshell.py", line 2883, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-21-64447dc5eb98>", line 1, in <module>
    print find_header('unistd.h')
  File "/usr/local/lib/python2.7/dist-packages/pyclibrary/utils.py", line 99, in find_header
    path = os.path.join(d, h_name)
  File "/usr/lib/python2.7/posixpath.py", line 70, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'tuple' object has no attribute 'endswith'
```