### PR TITLE
parser : adding support for C99 integers

### DIFF
--- a/pyclibrary/c_parser.py
+++ b/pyclibrary/c_parser.py
@@ -405,7 +405,8 @@ class CParser(object):
     """
     #: Increment every time cache structure or parsing changes to invalidate
     #: old cache files.
-    cache_version = 1
+    # 2 : add C99 integers
+    cache_version = 2
 
     #: Private flag allowing to know if the parser has been initiliased.
     _init = False
@@ -1675,7 +1676,9 @@ extra_modifier = None
 fund_type = None
 extra_type_list = []
 
-num_types = ['int', 'float', 'double']
+c99_int_types = ['int8_t', 'uint8_t', 'int16_t', 'uint16_t',
+                 'int32_t', 'uint32_t', 'int64_t', 'uint64_t']
+num_types = ['int', 'float', 'double'] + c99_int_types
 nonnum_types = ['char', 'bool', 'void']
 
 

--- a/tests/headers/variables.h
+++ b/tests/headers/variables.h
@@ -22,6 +22,16 @@ long long int long_long_int = 1;
 unsigned long long long_long_un = 1;
 unsigned long long int long_long_int_un = 1;
 
+// C99 integers
+int8_t i8 = 1;
+int16_t i16 = 1;
+int32_t i32 = 1;
+int64_t i64 = 1;
+uint8_t u8 = 1;
+uint16_t u16 = 1;
+uint32_t u32 = 1;
+uint64_t u64 = 1;
+
 // Floating points numbers
 float fl = + 1.0;
 double db = 1e-1;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -517,6 +517,13 @@ class TestParsing(object):
                 variables['long_long_int_un'] == (1, Type('unsigned long '
                                                           'long int')))
 
+        # C99 integers
+        for i in (8, 16, 32, 64):
+            assert ('i%d' % i in variables and
+                    variables['i%d' % i] == (1, Type('int%d_t' % i)))
+            assert ('u%d' % i in variables and
+                    variables['u%d' % i] == (1, Type('uint%d_t' % i)))
+
         # Floating point number
         assert ('fl' in variables and variables['fl'] ==
                 (1., Type('float')))


### PR DESCRIPTION
They were already there in ctypes backend.