### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ install:
   - python setup.py install
 
 script:
-  - py.test tests -m "not no_travis" -v --cov pyclibrary --cov-report term-missing
+  - cd ~
+  - export COVERAGE_DATAFILE=$TRAVIS_BUILD_DIR/.coverage
+  - pytest $TRAVIS_BUILD_DIR/tests -m "not no_travis" -v --cov pyclibrary --cov-report xml:$TRAVIS_BUILD_DIR/coverage.xml --cov-config $TRAVIS_BUILD_DIR/.coveragerc
 
 after_success:
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,50 @@
 sudo: false
+dist: trusty
 
-language: python
-python:
-    - 2.7
-    - 3.3
-    - 3.4
+branches:
+  only:
+    - master
+
+matrix:
+  include:
+    - env: PYTHON=2.7
+    - env: PYTHON=3.5
+    - env: PYTHON=3.6
 
 before_install:
-  - SRC_DIR=$(pwd)
-  - REDIRECT_TO=/dev/null # change to /dev/stdout to unsilence travis
+
+  # Install Miniconda
+  - travis_retry wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b -p ~/anaconda
+  - export PATH=~/anaconda/bin:$PATH
+
+  # Setup environment
+  - travis_retry conda update --yes conda
+  - conda config --set always_yes yes
+  - conda info -a
+  - conda create -n travisci python=$PYTHON pip
+  - source activate travisci
+  - CONDA_INSTALL="conda install -q"
+  - PIP_INSTALL="pip install -q"
+
+  # Install pyclibrary dependencies
+  - $CONDA_INSTALL future
+
+  # Intall test tools
+  - $CONDA_INSTALL pytest
+  - $PIP_INSTALL pytest-cov
+
+  # Install codecov report tools
+  - $PIP_INSTALL codecov
 
 install:
-  - pip install -q pytest future pytest-cov pytest-capturelog pytest-xdist
-  - pip install -q python-coveralls
+  - cd $TRAVIS_BUILD_DIR
+  - python setup.py install
 
 script:
-  - cd ${SRC_DIR}
-  - python setup.py install > ${REDIRECT_TO}
   - py.test tests -m "not no_travis" -v --cov pyclibrary --cov-report term-missing
 
 after_success:
-  - coveralls;
+  - cd $TRAVIS_BUILD_DIR
+  - codecov

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/MatthieuDartiailh/pyclibrary.svg?branch=master)](https://travis-ci.org/MatthieuDartiailh/pyclibrary)
 [![Coverage Status](https://coveralls.io/repos/MatthieuDartiailh/pyclibrary/badge.svg?branch=master)](https://coveralls.io/r/MatthieuDartiailh/pyclibrary?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/pyclibrary/badge/?version=latest)](https://readthedocs.org/projects/pyclibrary/?badge=latest)
-[![Latest Version](https://pypip.in/version/pyclibrary/badge.svg)](https://pypi.python.org/pypi/pyclibrary/)
-[![Downloads](https://pypip.in/download/pyclibrary/badge.svg)](https://pypi.python.org/pypi/pyclibrary/)
-[![Supported Python versions](https://pypip.in/py_versions/pyclibrary/badge.svg)](https://pypi.python.org/pypi/pyclibrary/)
-[![Wheel Status](https://pypip.in/wheel/pyclibrary/badge.svg)](https://pypi.python.org/pypi/pyclibrary/)
-[![License](https://pypip.in/license/pyclibrary/badge.svg)](https://pypi.python.org/pypi/pyclibrary/)
+[![Latest Version](https://img.shields.io/pypi/v/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)
+[![Downloads](https://img.shields.io/pypi/dm/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)
+[![Wheel Status](https://img.shields.io/pypi/wheel/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)
+[![License](https://img.shields.io/pypi/l/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)
 
 C parser and bindings automation for Python.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyClibrary
 
 [![Build Status](https://travis-ci.org/MatthieuDartiailh/pyclibrary.svg?branch=master)](https://travis-ci.org/MatthieuDartiailh/pyclibrary)
-[![Coverage Status](https://coveralls.io/repos/MatthieuDartiailh/pyclibrary/badge.svg?branch=master)](https://coveralls.io/r/MatthieuDartiailh/pyclibrary?branch=master)
+[![Coverage Status](https://codecov.io/gh/MatthieuDartiailh/pyclibrary/branch/master/graph/badge.svg)](https://codecov.io/gh/MatthieuDartiailh/pyclibrary)
 [![Documentation Status](https://readthedocs.org/projects/pyclibrary/badge/?version=latest)](https://readthedocs.org/projects/pyclibrary/?badge=latest)
 [![Latest Version](https://img.shields.io/pypi/v/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)
 [![Downloads](https://img.shields.io/pypi/dm/pyclibrary.svg)](https://pypi.python.org/pypi/pyclibrary/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment:
+  layout: header, changes, diff
+coverage:
+  status:
+    patch: false
+fixes:
+  - "~/anaconda/envs/travisci/Lib/site-packages/::"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -43,10 +43,10 @@ def teardown_module():
 
 @yield_fixture
 def library_location_fixture():
+    global LIBRARY_DIRS
     old = LIBRARY_DIRS[:]
     add_library_locations([os.path.dirname(_ctypes_test.__file__)])
     yield
-    global LIBRARY_DIRS
     LIBRARY_DIRS = old
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyclibrary))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyclibrary`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.