### PR TITLE
docs: Add future to requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinxcontrib-napoleon
+future


### PR DESCRIPTION
Tested the fix [here](https://readthedocs.org/projects/pyclibrary-aagallag/builds/7189217/) and now the build is passing on readthedocs.