### PR TITLE
Fix DeprecationWarning: 'U' mode is deprecated

### DIFF
--- a/pyclibrary/c_parser.py
+++ b/pyclibrary/c_parser.py
@@ -667,8 +667,14 @@ class CParser(object):
             self.files[path] = None
             return False
 
-        # U causes all newline types to be converted to \n
-        with open(path, 'rU') as fd:
+        if sys.version_info >= (3,):
+            open_mode = "r"
+        else:
+            # U causes all newline types to be converted to \n, but is the default from
+            # Python 3 on
+            open_mode = "rU"
+
+        with open(path, open_mode) as fd:
             self.files[path] = fd.read()
 
         if replace is not None:


### PR DESCRIPTION
'U' is the default since Python 3 and causes a warning since 3.4:
pyclibrary/c_parser.py:670: DeprecationWarning: 'U' mode is deprecated