### PR TITLE
Fix handling of nd array by ctypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 __pycache__
 .tox
 *.egg-info
+
+.mypy_cache

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyCLibrary Changelog
 ====================
 
+0.1.6 - unreleased
+------------------
+
+- fix issue when creating nd array in ctypes PR # 45
+
 0.1.5 - 24/06/2020
 ------------------
 

--- a/pyclibrary/backends/ctypes.py
+++ b/pyclibrary/backends/ctypes.py
@@ -185,19 +185,22 @@ class CTypesCLibrary(CLibrary):
 
 
             n_mods = []
+            # Go through the modifier looking for array modifiers.
+            # Array modifiers are list and if we find consecutive modifiers we merge
+            # them. This allows to iterate on them in reverse order to create the
+            # proper ctypes type
             if len(mods):
                 seen = mods[0]
                 for m in mods[1:]:
-                    # Merge consecutive array to be able to go in reverse when
-                    # creating the ctypes
                     if isinstance(seen, list) and isinstance(m, list):
                         seen += m
                     else:
                         n_mods.append(seen)
                         seen = m
                 n_mods.append(seen)
+            mods = n_mods
 
-            # apply pointers and arrays
+            # Apply pointers and arrays
             while len(mods) > 0:
                 m = mods.pop(0)
                 if istext(m):  # pointer or reference

--- a/pyclibrary/backends/ctypes.py
+++ b/pyclibrary/backends/ctypes.py
@@ -183,6 +183,20 @@ class CTypesCLibrary(CLibrary):
             if not pointers:
                 return cls
 
+
+            n_mods = []
+            if len(mods):
+                seen = mods[0]
+                for m in mods[1:]:
+                    # Merge consecutive array to be able to go in reverse when
+                    # creating the ctypes
+                    if isinstance(seen, list) and isinstance(m, list):
+                        seen += m
+                    else:
+                        n_mods.append(seen)
+                        seen = m
+                n_mods.append(seen)
+
             # apply pointers and arrays
             while len(mods) > 0:
                 m = mods.pop(0)
@@ -192,7 +206,8 @@ class CTypesCLibrary(CLibrary):
                             cls = POINTER(cls)
 
                 elif isinstance(m, list):      # array
-                    for i in m:
+                    # Go in reverse order to get nd array to work properly
+                    for i in reversed(m):
                         # -1 indicates an 'incomplete type' like "int
                         # variable[]"
                         if i == -1:

--- a/tests/backends/test_ctypes.py
+++ b/tests/backends/test_ctypes.py
@@ -63,6 +63,9 @@ class TestCTypesCLibrary(object):
     def test_make_struct(self):
         self.library.BITS
 
+    def test_make_ndarray(self):
+        assert "Array_20_Array_10" in str(self.library.T.names)
+
     def test_function_call1(self):
         # Test calling a function taking no arguments.
         res = self.library.get_an_integer()

--- a/tests/headers/ctypes_test.h
+++ b/tests/headers/ctypes_test.h
@@ -26,6 +26,10 @@ EXPORT(char *) my_strdup(char *src);
 // made of complex structures.
 
 typedef struct {
+    char names[10][20];
+} T;
+
+typedef struct {
     char *name;
     char *value;
 } SPAM;

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -12,6 +12,14 @@ struct struct_name
   char str[10]; /* commented brace } */
 } struct_inst;
 
+
+// Test creating a structure using only base types.
+// Test for default values, array handling and bit length specifications.
+struct struct_arr
+{
+  char str[10][20]; /* commented brace } */
+} struct_arr;
+
 // Test creating a pointer type from a structure.
 typedef struct struct_name *struct_name_ptr;
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -571,6 +571,8 @@ class TestParsing(object):
         # Test array handling
         assert ('array' in variables and
                 variables['array'] == ([1, 3141500.0], Type('float', [2])))
+        # assert ('array2d' in variables and
+        #         variables['array2d'] == ([[1, 2, 3], [4, 5, 6]], Type('float', [2, 3])))
         assert ('intJunk' in variables and
                 variables['intJunk'] == (
                     None,
@@ -682,6 +684,13 @@ class TestParsing(object):
                Struct(('x', Type('int'), 1),
                       ('y', Type('type_type_int'), None, 2),
                       ('str', Type('char', [10]), None))
+        assert ('struct_inst' in variables and
+                variables['struct_inst'] == (None, Type('struct struct_name')))
+
+        # Test creating a structure using only base types.
+        assert ('struct_arr' in structs and 'struct struct_arr' in types)
+        assert structs['struct_arr'] == \
+               Struct(('str', Type('char', [10], [20]), None))
         assert ('struct_inst' in variables and
                 variables['struct_inst'] == (None, Type('struct struct_name')))
 


### PR DESCRIPTION
For nd array we fuse modifiers into single list and go in reverse when creating the ctypes type