### PR TITLE
fix DeprecationWarning: invalid escape sequence \s

### DIFF
--- a/pyclibrary/c_parser.py
+++ b/pyclibrary/c_parser.py
@@ -1649,8 +1649,8 @@ rparen = Literal(")").ignore(quotedString).suppress()
 
 # Numbers
 int_strip = lambda t: t[0].rstrip('UL')
-hexint = Regex('[+-]?\s*0[xX][{}]+[UL]*'.format(hexnums)).setParseAction(int_strip)
-decint = Regex('[+-]?\s*[0-9]+[UL]*').setParseAction(int_strip)
+hexint = Regex(r'[+-]?\s*0[xX][{}]+[UL]*'.format(hexnums)).setParseAction(int_strip)
+decint = Regex(r'[+-]?\s*[0-9]+[UL]*').setParseAction(int_strip)
 integer = (hexint | decint)
 # The floating regex is ugly but it is because we do not want to match
 # integer to it.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -223,7 +223,7 @@ class TestFileHandling(object):
         path = os.path.join(self.h_dir, 'c_comments.h')
         self.parser.load_file(path)
         self.parser.remove_comments(path)
-        with open(os.path.join(self.h_dir, 'c_comments_removed.h'), 'rU') as f:
+        with open(os.path.join(self.h_dir, 'c_comments_removed.h'), 'r') as f:
             compare_lines(self.parser.files[path].split('\n'), f.readlines())
 
     def test_removing_cpp_comments(self):
@@ -232,7 +232,7 @@ class TestFileHandling(object):
         self.parser.load_file(path)
         self.parser.remove_comments(path)
         with open(os.path.join(self.h_dir,
-                               'cpp_comments_removed.h'), 'rU') as f:
+                               'cpp_comments_removed.h'), 'r') as f:
             compare_lines(self.parser.files[path].split('\n'), f.readlines())
 
 


### PR DESCRIPTION
This patch adds r"" markup to regexp strings. This warning is shown in our code when pytest parses all dependencies source files during its assert rewrite step.

The patch also removes the 'U' file opening mode, fixing `DeprecationWarning: 'U' mode is deprecated`.