### PR TITLE
Test support for Pyparsing 3.x and Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -45,3 +45,11 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true
+      - name: Test with oldest supported pyparsing
+        run: |
+          pip install pyparsing==2.3.1
+          python-m pytest tests
+      - name: Test with latest supported pyparsing
+        run: |
+          pip install --upgrade --upgrade-strategy eager pyparsing
+          python-m pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-      - name: Install project
+      - name: Install project with the latest dependency versions
         run: |
-          python setup.py develop
+          pip install --upgrade --upgrade-strategy eager -e .
       - name: Test with pytest
         run: |
           pip install pytest-cov
@@ -45,11 +45,7 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true
-      - name: Test with oldest supported pyparsing
+      - name: Test with the oldest supported dependency versions
         run: |
           pip install pyparsing==2.3.1
-          python -m pytest tests
-      - name: Test with latest supported pyparsing
-        run: |
-          pip install --upgrade --upgrade-strategy eager pyparsing
           python -m pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
     - cron: '0 0 * * 3'
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/ci.yml
       - pyclibrary/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Test with oldest supported pyparsing
         run: |
           pip install pyparsing==2.3.1
-          python-m pytest tests
+          python -m pytest tests
       - name: Test with latest supported pyparsing
         run: |
           pip install --upgrade --upgrade-strategy eager pyparsing
-          python-m pytest tests
+          python -m pytest tests

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 PyCLibrary Changelog
 ====================
 
+0.2.1 - 10/10/2022
+------------------
+
+- test compatibility with Python 3.10 PR #62
+- test compatibility with pyparsing 3.x PR #62
+
 0.2.0 - 03/10/2022
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,12 @@ cdll/windll.''',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
         ],
     zip_safe = False,
     packages = ['pyclibrary', 'pyclibrary.backends', 'pyclibrary.thirdparty'],
 	package_data = {'pyclibrary': ['headers/*']},
-    install_requires = ['pyparsing>=2.3.1,<3'],
+    install_requires = ['pyparsing>=2.3.1,<4'],
 )
 


### PR DESCRIPTION
Closes #61 

[Note about the upcoming pyparsing 3.1.0:](https://github.com/pyparsing/pyparsing/blob/master/CHANGES#L7) 

> NOTE: In the future release 3.1.0, use of many of the pre-PEP8 methods (such as
`ParserElement.parseString`) will start to raise `DeprecationWarnings`. 3.1.0 should
get released some time in August or September, 2022. I currently plan to completely
drop the pre-PEP8 methods in pyparsing 4.0, though we won't see that release until
at least late 2023.