### PR TITLE
allow selection of encoding when loading files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 PyCLibrary Changelog
 ====================
 
+0.2.3 - unreleased
+------------------
+
+- allow selection of encoding when loading files (issue #51)
+
 0.2.2 - 22/01/2024
 ------------------
 


### PR DESCRIPTION
Apparently the changes from PR #73 where not sufficient for some cases. As we can see from issue 51, some different encodings may be necessary for some legacy c files.

Fixes #51