### PR TITLE
Fix parsing of enum types as function arguments

### DIFF
--- a/pyclibrary/c_parser.py
+++ b/pyclibrary/c_parser.py
@@ -1481,7 +1481,10 @@ class CParser(object):
                         break
                     n += 1
             else:
-                name = t.name[0]
+                if isinstance(t.name, str):
+                    name = t.name
+                else:
+                    name = t.name[0]
 
             logger.debug("  name: {}".format(name))
 

--- a/tests/headers/enums.h
+++ b/tests/headers/enums.h
@@ -22,3 +22,5 @@ typedef enum
     typedef_enum1 = 1,
     typedef_enum2
 } no_name_enum_typeddef;
+
+void function_taking_enum(enum enum_name e);

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -719,6 +719,7 @@ class TestParsing(object):
         enums = self.parser.defs["enums"]
         types = self.parser.defs["types"]
         variables = self.parser.defs["variables"]
+        functions = self.parser.defs["functions"]
         print(self.parser.defs["values"])
         assert "enum_name" in enums and "enum enum_name" in types
         assert enums["enum_name"] == {"enum1": 129, "enum2": 6, "enum3": 7, "enum4": 8}
@@ -736,6 +737,11 @@ class TestParsing(object):
         assert "anon_enum0" in enums
         assert "anon_enum1" in enums
         assert "no_name_enum_typeddef" in types
+
+        assert "function_taking_enum" in functions
+        assert functions["function_taking_enum"] == Type(
+            Type("void"), (("e", Type("enum enum_name"), None),)
+        )
 
     def test_struct(self):
         path = os.path.join(self.h_dir, "structs.h")


### PR DESCRIPTION
When using an enum as a function argument:
```c
void function_taking_enum(enum enum_name e);
```

...the parser was truncating `enum_name` to the first character, so the type was becoming `enum e e`. This fixes that, and adds a test to check. All other tests still pass.