### PR TITLE
Add missing size_t/ssize_t/time_t

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ PyCLibrary Changelog
 - drop support for Python < 3.9 PR #78
 - move installation to pyproject base installation procedure PR #78
 - allow selection of encoding when loading files (issue #51)
+- fix parsing of enum types as function arguments PR #79
+- support size_t/ssize_t/time_t types PR #80
 
 0.2.2 - 22/01/2024
 ------------------

--- a/pyclibrary/backends/ctypes.py
+++ b/pyclibrary/backends/ctypes.py
@@ -34,6 +34,8 @@ from ctypes import (
     c_longdouble,
     c_longlong,
     c_short,
+    c_size_t,
+    c_ssize_t,
     c_ubyte,
     c_uint,
     c_uint8,
@@ -54,6 +56,9 @@ from inspect import cleandoc
 
 if sys.platform == "win32":
     from ctypes import HRESULT, WINFUNCTYPE, oledll, windll
+
+if sys.version_info >= (3, 12):
+    from ctypes import c_time_t
 
 from ..c_library import CLibrary
 from ..errors import DefinitionError
@@ -425,12 +430,17 @@ def init_clibrary(extra_types={}):
         "int32_t": c_int32,
         "uint64_t": c_uint64,
         "int64_t": c_int64,
+        "size_t": c_size_t,
+        "ssize_t": c_ssize_t,
     }
 
     if sys.platform == "win32":
         for k in extra_types:
             if k in WIN_TYPES:
                 extra_types[k] = WIN_TYPES[k]
+
+    if sys.version_info >= (3, 12):
+        extra_types['time_t'] = c_time_t
 
     # Now complete the list with some more exotic types
     CTypesCLibrary._types_.update(extra_types)

--- a/tests/headers/variables.h
+++ b/tests/headers/variables.h
@@ -22,6 +22,10 @@ long long int long_long_int = 1;
 unsigned long long long_long_un = 1;
 unsigned long long int long_long_int_un = 1;
 
+// stddef integers
+size_t size = 1;
+ssize_t ssize = 1;
+
 // C99 integers
 int8_t i8 = 1;
 int16_t i16 = 1;
@@ -59,6 +63,9 @@ int x2 = (typeCast)0x544 <<16;
 // Test array
 float array[2] = {0x1, 3.1415e6};
 static const int * const (**intJunk[4]);
+
+// time_t
+time_t time = 1;
 
 const int * volatile * typeQualedIntPtrPtr, volatile * typeQualedIntPtr;
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -563,6 +563,16 @@ class TestParsing(object):
             Type("unsigned long " "long int"),
         )
 
+        # stddef integers
+        assert "size" in variables and variables["size"] == (
+            1,
+            Type("size_t"),
+        )
+        assert "ssize" in variables and variables["ssize"] == (
+            1,
+            Type("ssize_t"),
+        )
+
         # C99 integers
         for i in (8, 16, 32, 64):
             assert "i%d" % i in variables and variables["i%d" % i] == (
@@ -637,6 +647,13 @@ class TestParsing(object):
                 type_quals=(("const",), ("const",), (), (), ()),
             ),
         )
+
+        # time_t
+        if sys.version_info >= (3, 12):
+            assert "time" in variables and variables["time"] == (
+                1,
+                Type("time_t"),
+            )
 
         # test type qualifiers
         assert variables.get("typeQualedIntPtrPtr") == (


### PR DESCRIPTION
Adds the missing `size_t`/`ssize_t` from ctypes, and also threw in the `time_t` type, which is new in Python 3.12. `ssize_t` was added in 3.2, but your minimum supported version is 3.10 so I didn't gate that one.

Closes #49 