### PR TITLE
feat(sizeof): add support for sizeof

### DIFF
--- a/pyclibrary/c_parser.py
+++ b/pyclibrary/c_parser.py
@@ -1248,6 +1248,9 @@ class CParser(object):
             )
         )
 
+        # https://en.cppreference.com/w/cpp/language/type-id.html#Type_naming
+        sizeof_types << self.abstract_declarator
+
         # Declarators look like:
         #     varName
         #     *varName
@@ -1803,7 +1806,7 @@ number = floating | integer
 # Miscelaneous
 bi_operator = oneOf("+ - / * | & || && ! ~ ^ % == != > < >= <= -> . :: << >> = ? :")
 uni_right_operator = oneOf("++ --")
-uni_left_operator = oneOf("++ -- - + * sizeof new")
+uni_left_operator = oneOf("++ -- - + * new")
 wordchars = alphanums + "_$"
 name = WordStart(wordchars) + Word(alphas + "_", alphanums + "_$") + WordEnd(wordchars)
 size_modifiers = ["short", "long"]
@@ -1820,6 +1823,7 @@ storage_class_spec = None
 extra_modifier = None
 fund_type = None
 extra_type_list = []
+sizeof_types = Forward()
 
 c99_int_types = [
     "int8_t",
@@ -1939,7 +1943,7 @@ def _init_cparser(extra_types=None, extra_modifiers=None):
         + ZeroOrMore(uni_right_operator)
     )
 
-    atom = cast_atom | uncast_atom
+    atom = ("sizeof" + expression) | ("sizeof" + sizeof_types) | cast_atom | uncast_atom
 
     expression << Group(atom + ZeroOrMore(bi_operator + atom))
     expression.setParseAction(recombine)

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -15,6 +15,7 @@ struct sizeof_st {
   char u[sizeof 1 + sizeof 2];
   char v[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
   char w[sizeof(int) + sizeof(float)];
+  char t[8 - sizeof(int*)]
 };
 
 // Test creating a structure using only base types.

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -5,7 +5,7 @@ typedef type_int type_type_int;
 
 struct sizeof_child {
   int x[sizeof(int[2])];
-}
+};
 
 /* test sizeof operator */
 struct sizeof_st {
@@ -15,7 +15,7 @@ struct sizeof_st {
   char u[sizeof 1 + sizeof 2];
   char v[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
   char w[sizeof(int) + sizeof(float)];
-}
+};
 
 // Test creating a structure using only base types.
 // Test for default values, array handling and bit length specifications.

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -15,7 +15,7 @@ typedef struct sizeof_st {
   char u[sizeof 1 + sizeof 2];
   char v[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
   char w[sizeof(int) + sizeof(float)];
-  char t[47 - sizeof(sizeof_child*)];
+  char t[47 - sizeof(struct sizeof_child*)];
   int bar;
 } sizeof_st_t;
 

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -10,10 +10,11 @@ struct sizeof_child {
 /* test sizeof operator */
 struct sizeof_st {
   char x[sizeof(int*)];
-  char y[sizeof(sizeof_st*)];
-  char z[sizeof(sizeof_child)];
+  char y[sizeof(struct sizeof_st*)];
+  char z[sizeof(struct sizeof_child)];
+  char u[sizeof 1 + sizeof 2];
+  char v[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
   char w[sizeof(int) + sizeof(float)];
-  char u[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
 }
 
 // Test creating a structure using only base types.

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -15,7 +15,7 @@ struct sizeof_st {
   char u[sizeof 1 + sizeof 2];
   char v[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
   char w[sizeof(int) + sizeof(float)];
-  char t[8 - sizeof(int*)]
+  char t[8 - sizeof(sizeof_child**)];
 };
 
 // Test creating a structure using only base types.

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -8,15 +8,16 @@ struct sizeof_child {
 };
 
 /* test sizeof operator */
-struct sizeof_st {
+typedef struct sizeof_st {
   char x[sizeof(int*)];
   char y[sizeof(struct sizeof_st*)];
   char z[sizeof(struct sizeof_child)];
   char u[sizeof 1 + sizeof 2];
   char v[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
   char w[sizeof(int) + sizeof(float)];
-  char t[8 - sizeof(sizeof_child**)];
-};
+  char t[47 - sizeof(sizeof_child*)];
+  int bar;
+} sizeof_st_t;
 
 // Test creating a structure using only base types.
 // Test for default values, array handling and bit length specifications.

--- a/tests/headers/structs.h
+++ b/tests/headers/structs.h
@@ -3,6 +3,19 @@
 typedef int type_int;
 typedef type_int type_type_int;
 
+struct sizeof_child {
+  int x[sizeof(int[2])];
+}
+
+/* test sizeof operator */
+struct sizeof_st {
+  char x[sizeof(int*)];
+  char y[sizeof(sizeof_st*)];
+  char z[sizeof(sizeof_child)];
+  char w[sizeof(int) + sizeof(float)];
+  char u[sizeof (1) + sizeof (2) + sizeof(sizeof(int*))];
+}
+
 // Test creating a structure using only base types.
 // Test for default values, array handling and bit length specifications.
 struct struct_name

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -961,3 +961,17 @@ class TestParsing(object):
         assert functions.get("typeQualedFunc") == Type(
             Type("int"), ((None, ptyp, None),)
         )
+
+    def test_sizeof(self):
+        path = os.path.join(self.h_dir, "structs.h")
+        self.parser.load_file(path)
+        self.parser.process_all()
+
+        structs = self.parser.defs["structs"]
+        assert structs["sizeof_st"] == Struct(
+            ("x", Type("char", [None]), None),
+            ("y", Type("char", [None]), None),
+            ("z", Type("char", [None]), None),
+            ("w", Type("char", [None]), None),
+            ("u", Type("char", [None]), None),
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -976,4 +976,5 @@ class TestParsing(object):
             ("v", Type("char", [None]), None),
             ("w", Type("char", [None]), None),
             ("t", Type("char", [None]), None),
+            ("bar", Type("int"), None),
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -972,6 +972,7 @@ class TestParsing(object):
             ("x", Type("char", [None]), None),
             ("y", Type("char", [None]), None),
             ("z", Type("char", [None]), None),
-            ("w", Type("char", [None]), None),
             ("u", Type("char", [None]), None),
+            ("v", Type("char", [None]), None),
+            ("w", Type("char", [None]), None),
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -975,4 +975,5 @@ class TestParsing(object):
             ("u", Type("char", [None]), None),
             ("v", Type("char", [None]), None),
             ("w", Type("char", [None]), None),
+            ("t", Type("char", [None]), None),
         )


### PR DESCRIPTION
This PR adds support for the `sizeof` operator in both forms: type-id (which
accepts _abstract-declarator_ s) and expression which accepts expressions.

I'm happy to add more tests as requested.

Things to note:

1. I didn't modify the evaluator to constant-fold in the actual size. That
   seemed like a hairy issue. If that's a requirement, I can look into it.
1. I didn't roll this into `atom` because `sizeof` needs access to the full
   declarator parser and that didn't fit neatly into either of the atom rules.
1. The array-of-pointers case doesn't seem like it's supported, so that isn't supported here.
