### PR TITLE
Fix parsing of integers with lowercase `ull` suffix

### DIFF
--- a/pyclibrary/c_parser.py
+++ b/pyclibrary/c_parser.py
@@ -1789,9 +1789,9 @@ lparen = Literal("(").ignore(quotedString).suppress()
 rparen = Literal(")").ignore(quotedString).suppress()
 
 # Numbers
-int_strip = lambda t: t[0].rstrip("UL")  # noqa
-hexint = Regex(r"[+-]?\s*0[xX][{}]+[UL]*".format(hexnums)).setParseAction(int_strip)
-decint = Regex(r"[+-]?\s*[0-9]+[UL]*").setParseAction(int_strip)
+int_strip = lambda t: t[0].rstrip("UuLl")  # noqa
+hexint = Regex(r"[+-]?\s*0[xX][{}]+[UuLl]*".format(hexnums)).setParseAction(int_strip)
+decint = Regex(r"[+-]?\s*[0-9]+[UuLl]*").setParseAction(int_strip)
 integer = hexint | decint
 # The floating regex is ugly but it is because we do not want to match
 # integer to it.

--- a/tests/headers/variables.h
+++ b/tests/headers/variables.h
@@ -21,6 +21,8 @@ long long long_long = 1;
 long long int long_long_int = 1;
 unsigned long long long_long_un = 1;
 unsigned long long int long_long_int_un = 1;
+unsigned long long int long_long_int_upper = 1ULL;
+unsigned long long int long_long_int_lower = 1ull;
 
 // stddef integers
 size_t size = 1;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -604,6 +604,14 @@ class TestParsing(object):
             1,
             Type("unsigned long " "long int"),
         )
+        assert "long_long_int_upper" in variables and variables["long_long_int_upper"] == (
+            1,
+            Type("unsigned long " "long int"),
+        )
+        assert "long_long_int_lower" in variables and variables["long_long_int_lower"] == (
+            1,
+            Type("unsigned long " "long int"),
+        )
 
         # stddef integers
         assert "size" in variables and variables["size"] == (


### PR DESCRIPTION
I updated my clang-format config, and realised some values disappeared from my type generation as they were no longer being considered ints 😅 